### PR TITLE
Add brand asset mapping & example compose file

### DIFF
--- a/brand-assets/README.md
+++ b/brand-assets/README.md
@@ -1,0 +1,16 @@
+# Brand Assets
+
+This folder contains files used to customize the NocoDB UI branding and its Open Graph meta tags. Replace the images in `./assets` with your own to change the look of the UI and previews.
+
+The mapping of each file to its destination inside the project is stored in `assets.json`. During the local docker build the files listed in that mapping are copied into the NocoDB sources before the GUI build step.
+
+Add your own versions of these files keeping the same names and formats. Dimensions of the original images are recorded in `assets.json` for reference.
+
+The UI meta tags can be customized by setting these environment variables:
+
+- `NC_BRAND_SITE_NAME`
+- `NC_BRAND_TITLE`
+- `NC_BRAND_DESCRIPTION`
+- `NC_BRAND_URL`
+
+See `docker-compose/2_pg_branded/docker-compose.yml` for an example of how to provide them when running with Docker Compose.

--- a/brand-assets/assets.json
+++ b/brand-assets/assets.json
@@ -1,0 +1,32 @@
+[
+  {
+    "filename": "main-logo.png",
+    "target": "packages/nc-gui/assets/img/brand/nocodb-full.png",
+    "resolution": "600x171",
+    "description": "Main large logo shown in the header"
+  },
+  {
+    "filename": "compact-logo.png",
+    "target": "packages/nc-gui/assets/img/brand/nocodb.png",
+    "resolution": "629x99",
+    "description": "Compact logo used on share pages"
+  },
+  {
+    "filename": "logo-icon.svg",
+    "target": "packages/nc-gui/assets/img/brand/nocodb-logo.svg",
+    "resolution": "24x24",
+    "description": "Small logo icon used throughout the UI"
+  },
+  {
+    "filename": "favicon.ico",
+    "target": "packages/nc-gui/public/favicon.ico",
+    "resolution": "256x256",
+    "description": "Browser tab icon"
+  },
+  {
+    "filename": "link-preview.webp",
+    "target": "packages/nc-gui/public/link-preview.webp",
+    "resolution": "800x450",
+    "description": "Open graph / Twitter preview image"
+  }
+]

--- a/brand-assets/assets/logo-icon.svg
+++ b/brand-assets/assets/logo-icon.svg
@@ -1,0 +1,20 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+        d="M6 10.8676L8.75329 13.6226V17.9842H6V10.8676ZM17.5645 5.01046V17.535C17.5645 17.7921 17.3548 18 17.0977 18C16.9744 18 16.8563 17.9525 16.7683 17.8644L6 8.15303V5.40504C6 5.14785 6.20787 4.94 6.46505 4.94H6.48972C6.61303 4.94 6.7328 4.98933 6.81911 5.07564L14.8094 12.009V5.01046H17.5645Z"
+        fill="url(#paint0_linear_231_10218)" />
+    <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M3 0C1.34315 0 0 1.34315 0 3V21C0 22.6569 1.34315 24 3 24H21C22.6569 24 24 22.6569 24 21V3C24 1.34315 22.6569 0 21 0H3ZM3.63333 2.13333C2.8049 2.13333 2.13333 2.8049 2.13333 3.63333V20.3667C2.13333 21.1951 2.8049 21.8667 3.63333 21.8667H20.3667C21.1951 21.8667 21.8667 21.1951 21.8667 20.3667V3.63333C21.8667 2.8049 21.1951 2.13333 20.3667 2.13333H3.63333Z"
+        fill="url(#paint1_linear_231_10218)" />
+    <defs>
+        <linearGradient id="paint0_linear_231_10218" x1="11.7814" y1="0.543214" x2="11.7814" y2="21.6612"
+            gradientUnits="userSpaceOnUse">
+            <stop stop-color="#4351E8" />
+            <stop offset="1" stop-color="#2A1EA5" />
+        </linearGradient>
+        <linearGradient id="paint1_linear_231_10218" x1="4.82267" y1="19.1431" x2="26.7035" y2="-2.6331"
+            gradientUnits="userSpaceOnUse">
+            <stop stop-color="#4351E8" />
+            <stop offset="1" stop-color="#2A1EA5" />
+        </linearGradient>
+    </defs>
+</svg>

--- a/build-local-docker-image.sh
+++ b/build-local-docker-image.sh
@@ -29,6 +29,22 @@ function install_dependencies() {
     pnpm bootstrap || ERROR="install_dependencies failed"
 }
 
+function apply_branding() {
+    local MAP_FILE="${SCRIPT_DIR}/brand-assets/assets.json"
+    if [ -f "$MAP_FILE" ]; then
+        jq -c '.[]' "$MAP_FILE" | while read -r item; do
+            local filename=$(echo "$item" | jq -r '.filename')
+            local target=$(echo "$item" | jq -r '.target')
+            local src="${SCRIPT_DIR}/brand-assets/assets/${filename}"
+            local dest="${SCRIPT_DIR}/${target}"
+            if [ -f "$src" ]; then
+                echo "Info: applying branding $src -> $dest" | tee -a ${LOG_FILE}
+                cp "$src" "$dest" || ERROR="apply_branding failed"
+            fi
+        done
+    fi
+}
+
 function build_gui() {
     # build nc-gui
     export NODE_OPTIONS="--max_old_space_size=16384"
@@ -71,6 +87,9 @@ remove_image
 
 echo "Info: Installing dependencies" | tee -a ${LOG_FILE}
 install_dependencies 1>> ${LOG_FILE} 2>> ${LOG_FILE}
+
+echo "Info: Applying custom brand assets" | tee -a ${LOG_FILE}
+apply_branding 1>> ${LOG_FILE} 2>> ${LOG_FILE}
 
 echo "Info: Building nc-gui" | tee -a ${LOG_FILE}
 build_gui 1>> ${LOG_FILE} 2>> ${LOG_FILE}

--- a/docker-compose/2_pg_branded/docker-compose.yml
+++ b/docker-compose/2_pg_branded/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '2.1'
+services: 
+  nocodb: 
+    depends_on: 
+      root_db: 
+        condition: service_healthy
+    environment:
+      NC_DB: "pg://root_db:5432?u=postgres&p=password&d=root_db"
+      NC_BRAND_SITE_NAME: "AcmeDB"
+      NC_BRAND_TITLE: "Acme DB"
+      NC_BRAND_DESCRIPTION: "Self-hosted collaborative database platform"
+      NC_BRAND_URL: "https://example.com"
+    image: "nocodb/nocodb:latest"
+    ports: 
+      - "8080:8080"
+    restart: always
+    volumes: 
+      - "nc_data:/usr/app/data"
+  root_db: 
+    environment: 
+      POSTGRES_DB: root_db
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: postgres
+    healthcheck: 
+      interval: 10s
+      retries: 10
+      test: "pg_isready -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\""
+      timeout: 2s
+    image: postgres:16.6
+    restart: always
+    volumes: 
+      - "db_data:/var/lib/postgresql/data"
+volumes: 
+  db_data: {}
+  nc_data: {}

--- a/packages/nc-gui/layouts/base.vue
+++ b/packages/nc-gui/layouts/base.vue
@@ -9,6 +9,8 @@ const { isFeatureEnabled } = useBetaFeatureToggle()
 
 const email = computed(() => user.value?.email ?? '---')
 
+const brandTitle = useRuntimeConfig().public.ncBrandTitle || 'NocoDB'
+
 const hasSider = ref(false)
 
 const sidebar = ref<HTMLDivElement>()
@@ -51,8 +53,8 @@ hooks.hook('page:finish', () => {
               {{ currentVersion }}
             </template>
             <div class="flex items-center gap-2">
-              <img v-if="!isDashboard" width="120" alt="NocoDB" src="~/assets/img/brand/nocodb-full.png" />
-              <img v-else width="25" alt="NocoDB" src="~/assets/img/icons/256x256.png" />
+              <img v-if="!isDashboard" width="120" :alt="brandTitle" src="~/assets/img/brand/nocodb-full.png" />
+              <img v-else width="25" :alt="brandTitle" src="~/assets/img/icons/256x256.png" />
             </div>
           </a-tooltip>
         </div>

--- a/packages/nc-gui/layouts/default.vue
+++ b/packages/nc-gui/layouts/default.vue
@@ -11,7 +11,8 @@ const refreshSidebar = ref(false)
 
 const sidebarReady = ref(false)
 
-useTitle(route.meta?.title && te(route.meta.title) ? `${t(route.meta.title)}` : 'NocoDB')
+const brandTitle = useRuntimeConfig().public.ncBrandTitle || 'NocoDB'
+useTitle(route.meta?.title && te(route.meta.title) ? `${t(route.meta.title)}` : brandTitle)
 
 watch(hasSidebar, (val) => {
   if (!val) {

--- a/packages/nc-gui/layouts/new.vue
+++ b/packages/nc-gui/layouts/new.vue
@@ -17,7 +17,8 @@ const email = computed(() => user.value?.email ?? '---')
 
 const refreshSidebar = ref(false)
 
-useTitle(route.meta?.title && te(route.meta.title) ? `${t(route.meta.title)}` : 'NocoDB')
+const brandTitle = useRuntimeConfig().public.ncBrandTitle || 'NocoDB'
+useTitle(route.meta?.title && te(route.meta.title) ? `${t(route.meta.title)}` : brandTitle)
 
 const isPublic = computed(() => route.meta?.public)
 

--- a/packages/nc-gui/layouts/shared-view.vue
+++ b/packages/nc-gui/layouts/shared-view.vue
@@ -38,10 +38,11 @@ onMounted(() => {
   }
 
   // handle meta title
+  const brandTitle = useRuntimeConfig().public.ncBrandTitle || 'NocoDB'
   if (sharedView.value?.title) {
     document.title = `${sharedView.value.title}`
   } else {
-    document.title = 'NocoDB'
+    document.title = brandTitle
   }
 })
 </script>
@@ -68,7 +69,7 @@ export default {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <img width="96" alt="NocoDB" src="~/assets/img/brand/nocodb.png" class="flex-none min-w-[96px]" />
+              <img width="96" :alt="brandTitle" src="~/assets/img/brand/nocodb.png" class="flex-none min-w-[96px]" />
             </a>
 
             <div class="flex items-center gap-2 text-gray-900 text-sm truncate">

--- a/packages/nc-gui/nuxt.config.ts
+++ b/packages/nc-gui/nuxt.config.ts
@@ -9,6 +9,13 @@ import { FileSystemIconLoader } from 'unplugin-icons/loaders'
 
 import PurgeIcons from 'vite-plugin-purge-icons'
 
+const BRAND_SITE_NAME = process.env.NC_BRAND_SITE_NAME || 'NocoDB'
+const BRAND_TITLE = process.env.NC_BRAND_TITLE || BRAND_SITE_NAME
+const BRAND_DESCRIPTION =
+  process.env.NC_BRAND_DESCRIPTION ||
+  'NocoDB provides an intuitive spreadsheet interface for creating online databases, either from scratch or by connecting to any Postgres/MySQL. Access your data through interactive UIs or via API and SQL. Get started for free.'
+const BRAND_URL = process.env.NC_BRAND_URL || 'https://nocodb.com'
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   future: {
@@ -77,24 +84,22 @@ export default defineNuxtConfig({
           content: process.env.npm_package_description || '',
         },
         // Open Graph
-        { hid: 'og:site_name', property: 'og:site_name', content: 'NocoDB' },
+        { hid: 'og:site_name', property: 'og:site_name', content: BRAND_SITE_NAME },
         { hid: 'og:type', property: 'og:type', content: 'website' },
-        { hid: 'og:title', property: 'og:title', content: 'NocoDB' },
+        { hid: 'og:title', property: 'og:title', content: BRAND_TITLE },
         {
           hid: 'og:description',
           property: 'og:description',
-          content:
-            'NocoDB provides an intuitive spreadsheet interface for creating online databases, either from scratch or by connecting to any Postgres/MySQL. Access your data through interactive UIs or via API and SQL. Get started for free.',
+          content: BRAND_DESCRIPTION,
         },
-        { hid: 'og:url', property: 'og:url', content: 'https://nocodb.com' },
+        { hid: 'og:url', property: 'og:url', content: BRAND_URL },
         // Twitter
         { hid: 'twitter:card', name: 'twitter:card', content: 'summary_large_image' },
-        { hid: 'twitter:title', name: 'twitter:title', content: 'NocoDB' },
+        { hid: 'twitter:title', name: 'twitter:title', content: BRAND_TITLE },
         {
           hid: 'twitter:description',
           name: 'twitter:description',
-          content:
-            'NocoDB provides an intuitive spreadsheet interface for creating online databases, either from scratch or by connecting to any Postgres/MySQL. Access your data through interactive UIs or via API and SQL. Get started for free.',
+          content: BRAND_DESCRIPTION,
         },
         {
           hid: 'twitter:image',
@@ -124,6 +129,10 @@ export default defineNuxtConfig({
       ncBackendUrl: '',
       env: 'production',
       maxPageDesignerTableRows: 100,
+      ncBrandSiteName: BRAND_SITE_NAME,
+      ncBrandTitle: BRAND_TITLE,
+      ncBrandDescription: BRAND_DESCRIPTION,
+      ncBrandUrl: BRAND_URL,
     },
   },
 


### PR DESCRIPTION
## Summary
- document branding assets and environment variables
- add mapping for brand asset placement
- include compose example showing brand variables
- copy custom brand assets during Docker image build
- expose brand metadata in runtime config
- remove large image placeholders

## Testing
- `pnpm -r run lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_6845515fc6908328bc8ae89a6fe7ce39